### PR TITLE
chore: add observability config and unify wrangler format to jsonc

### DIFF
--- a/boilerplates/cf-worker/wrangler.jsonc
+++ b/boilerplates/cf-worker/wrangler.jsonc
@@ -1,0 +1,28 @@
+{
+  "name": "myapp",
+  "main": "src/index.ts",
+  "compatibility_date": "2024-01-01",
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "persist": true,
+      "invocation_logs": true
+    },
+    "traces": {
+      "enabled": true,
+      "persist": true,
+      "head_sampling_rate": 1
+    }
+  },
+  "env": {
+    "test": {
+      "name": "myapp-test"
+    },
+    "production": {
+      "name": "myapp"
+    }
+  }
+}

--- a/boilerplates/cf-worker/wrangler.toml
+++ b/boilerplates/cf-worker/wrangler.toml
@@ -1,9 +1,0 @@
-name = "myapp"
-main = "src/index.ts"
-compatibility_date = "2024-01-01"
-
-[env.test]
-name = "myapp-test"
-
-[env.production]
-name = "myapp"

--- a/boilerplates/dashboard/wrangler.jsonc
+++ b/boilerplates/dashboard/wrangler.jsonc
@@ -2,5 +2,20 @@
   "name": "myapp",
   "compatibility_date": "2024-09-23",
   "compatibility_flags": ["nodejs_compat"],
-  "pages_build_output_dir": "./dist"
+  "pages_build_output_dir": "./dist",
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "persist": true,
+      "invocation_logs": true
+    },
+    "traces": {
+      "enabled": true,
+      "persist": true,
+      "head_sampling_rate": 1
+    }
+  }
 }

--- a/boilerplates/landing/wrangler.jsonc
+++ b/boilerplates/landing/wrangler.jsonc
@@ -2,5 +2,20 @@
   "name": "myapp",
   "compatibility_date": "2024-09-23",
   "compatibility_flags": ["nodejs_compat"],
-  "pages_build_output_dir": "./dist"
+  "pages_build_output_dir": "./dist",
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "persist": true,
+      "invocation_logs": true
+    },
+    "traces": {
+      "enabled": true,
+      "persist": true,
+      "head_sampling_rate": 1
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Convert `cf-worker/wrangler.toml` to `wrangler.jsonc` for consistency across all boilerplates
- Add observability configuration to all three wrangler boilerplates (cf-worker, dashboard, landing)
- Enable logs (with `persist` and `invocation_logs`) and traces (with `persist`) at 100% sampling rate

## Testing

- Not run (not requested)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced observability features across boilerplate projects with logging and trace configuration support.

* **Configuration**
  * Updated Cloudflare Worker boilerplate configuration format and structure.
  * Enabled observability with sampling rates and persistence options for improved monitoring and debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->